### PR TITLE
Resolve relative path to mm script

### DIFF
--- a/make/mm.py
+++ b/make/mm.py
@@ -358,7 +358,7 @@ class Installer:
 class Builder:
     """The {mm} wrapper"""
 
-    mm = "{} {}".format(sys.executable, sys.argv[0])
+    mm = "{} {}".format(sys.executable, os.path.abspath(sys.argv[0]))
     mmdef = os.path.split(__file__)[0]
     home = os.path.abspath(os.path.join(mmdef, os.pardir))
     directory = os.getcwd()


### PR DESCRIPTION
mm builder uses argv[0] verbatim, leading to errors when invoking via e.g. `../config/make/mm.py build`